### PR TITLE
Removed code that effects our namespacing logic on arrays

### DIFF
--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -1600,11 +1600,12 @@ WSDL.prototype.objectToXML = function(obj, name, nsPrefix, nsURI, isFirst, xmlns
       var value = '';
       var nonSubNameSpace = '';
 
-      var nameWithNsRegex = /^([^:]+):([^:]+)$/.exec(name);
-      if (nameWithNsRegex) {
-        nonSubNameSpace = nameWithNsRegex[1] + ':';
-        name = nameWithNsRegex[2];
-      }
+      // @NOTE: Removed so that manually assigning namespaces for array elements works
+      // var nameWithNsRegex = /^([^:]+):([^:]+)$/.exec(name);
+      // if (nameWithNsRegex) {
+      //   nonSubNameSpace = nameWithNsRegex[1] + ':';
+      //   name = nameWithNsRegex[2];
+      // }
 
       if (isFirst) {
         value = self.objectToXML(child, name, nsPrefix, nsURI, false, null, schemaObject, nsContext);


### PR DESCRIPTION
By removing this section of code when we send arrays in SOAP XML with manually prefixed namespaces it works without stripping the manually added namespace.
